### PR TITLE
Disable DEBUG logging by default

### DIFF
--- a/buildhat/serinterface.py
+++ b/buildhat/serinterface.py
@@ -245,7 +245,7 @@ class BuildHAT:
             u = (u ^ data[i]) & 0xFFFFFFFF
         return u
 
-    def write(self, data, log=True, replace=""):
+    def write(self, data, log=False, replace=""):
         """Write data to the serial port of Build HAT
 
         :param data: Data to write to Build HAT
@@ -259,7 +259,7 @@ class BuildHAT:
             else:
                 logging.debug(f"> {data.decode('utf-8', 'ignore').strip()}")
 
-    def read(self):
+    def read(self, log=False):
         """Read data from the serial port of Build HAT
 
         :return: Line that has been read
@@ -269,7 +269,7 @@ class BuildHAT:
             line = self.ser.readline().decode('utf-8', 'ignore').strip()
         except serial.SerialException:
             pass
-        if line != "":
+        if line != "" and log:
             logging.debug(f"< {line}")
         return line
 


### PR DESCRIPTION
If an application has its dlogging set to DEBUG, BuildHAT flods with a tonn of unwanted debug messages.

Usually one can suppress this with `logging.getLogger('<MODULE NAME>').setLevel(logging.WARNING)`, how ever none of my approaches worked:
```python
logging.getLogger('BuildHAT').setLevel(logging.WARNING)
logging.getLogger('Hat').setLevel(logging.WARNING)
logging.getLogger('Motor').setLevel(logging.WARNING)
```

So I ended up to disable the logging by default.
This seems to be correct on the `HAT` class level, but wrong down in the `BuildHAT`:
https://github.com/RaspberryPiFoundation/python-build-hat/blob/main/buildhat/hat.py#L11